### PR TITLE
Hotfix for ClassCastException

### DIFF
--- a/src/main/java/net/teamabyssalofficial/extra/ParasiteKillsBuffEvent.java
+++ b/src/main/java/net/teamabyssalofficial/extra/ParasiteKillsBuffEvent.java
@@ -18,6 +18,10 @@ public class ParasiteKillsBuffEvent {
     @SubscribeEvent
     public static void ParasiteBuffEvent(LivingDeathEvent event) {
         if (event != null && event.getEntity() != null && !event.getEntity().level().isClientSide && event.getSource().getEntity() != null) {
+            if(!(event.getSource().getEntity() instanceof LivingEntity)) {
+                return;
+            }
+            
             LivingEntity entity = (LivingEntity) event.getSource().getEntity();
             Level world = entity.level();
             WorldDataRegistry worldDataRegistry = WorldDataRegistry.getWorldDataRegistry((ServerLevel) world);


### PR DESCRIPTION
This should fix `java.lang.ClassCastException: class net.minecraft.world.entity.projectile.Arrow cannot be cast to class net.minecraft.world.entity.LivingEntity ` discussed in your [comment section](https://www.curseforge.com/minecraft/mc-mods/fight-or-die-mutations/comments) at CurseForge